### PR TITLE
fix: Add failure case to container build workflows

### DIFF
--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -75,6 +75,7 @@ jobs:
           - amd64
           - arm64
 
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: checkout 
       uses: actions/checkout@v3
@@ -116,3 +117,6 @@ jobs:
 
   on-failure:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'build-static-assets failed'

--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -22,6 +22,7 @@ jobs:
           - amd64
           - arm64
 
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: checkout 
       uses: actions/checkout@v3
@@ -112,3 +113,6 @@ jobs:
         ignore-unfixed: true
         vuln-type: 'os,library'
         severity: 'CRITICAL,HIGH'
+
+  on-failure:
+    runs-on: ubuntu-latest

--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -119,4 +119,5 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
-      - run: echo 'build-static-assets failed'
+      - name: error-message 
+        run: echo 'build-static-assets failed'

--- a/.github/workflows/php-container.yaml
+++ b/.github/workflows/php-container.yaml
@@ -21,7 +21,8 @@ jobs:
         platform:
           - amd64
           - arm64
-          
+
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}  
     steps:
     - name: checkout 
       uses: actions/checkout@v3
@@ -75,6 +76,7 @@ jobs:
           - amd64
           - arm64
 
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: checkout 
       uses: actions/checkout@v3
@@ -113,3 +115,10 @@ jobs:
         ignore-unfixed: true
         vuln-type: 'os,library'
         severity: 'CRITICAL,HIGH'
+
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: error-message 
+        run: echo 'build-static-assets failed'

--- a/.github/workflows/upload-container.yaml
+++ b/.github/workflows/upload-container.yaml
@@ -22,6 +22,7 @@ jobs:
           - amd64
           - arm64
 
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: checkout 
       uses: actions/checkout@v3
@@ -63,6 +64,7 @@ jobs:
           - amd64
           - arm64
 
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: checkout 
       uses: actions/checkout@v3
@@ -101,3 +103,10 @@ jobs:
         ignore-unfixed: true
         vuln-type: 'os,library'
         severity: 'CRITICAL,HIGH'
+
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: error-message 
+        run: echo 'build-static-assets failed'


### PR DESCRIPTION
This PR adds logic to the container build workflows that rely on the `build-static-assets` workflow. 

Prior, it did not matter what the outcome was for `build-static-assets`, rather only that it was `completed`. Now there is logic to check if the workflow was successful, or if it failed.