### PR TITLE
CI: Successful PEST tests trigger container build

### DIFF
--- a/.github/workflows/build-static-assets.yaml
+++ b/.github/workflows/build-static-assets.yaml
@@ -1,11 +1,9 @@
 name: Build static assets
 
 on:
-  workflow_run:
-    workflows: [Pest Tests]
-    branches: [main]
-    types:
-      - completed
+  push:
+    branches:
+      - main
 
 jobs:
   build-static-assets:


### PR DESCRIPTION
### Description

The purpose of this PR is have successful PEST test runs in CI trigger a build of the application container. I had mistakenly tried to have the `build-static-assets` step run on a succesful `workflow_run` without understanding things entirely. Should be fixed after this.

The workflow being successful will not trigger the build, but when the PR is merged into `main`, this will trigger the build process. 