### PR TITLE
CI: Fix triggers for container build workflows

### DIFF
--- a/.github/workflows/build-static-assets.yaml
+++ b/.github/workflows/build-static-assets.yaml
@@ -8,8 +8,7 @@ on:
 jobs:
   build-static-assets:
     runs-on: ubuntu-latest
-
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    
     steps:
     - name: checkout
       uses: actions/checkout@v3
@@ -26,10 +25,3 @@ jobs:
         name: static-assets
         path: public/build
         include-hidden-files: true
-
-  on-failure:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    steps:
-      - name: error-message 
-        run: echo 'pest tests failed'


### PR DESCRIPTION
### Description

This PR updates the `build-static-assets` step to not use `if` conditions to check the status of a workflow, as. it is unnecessary after implementing the PEST tests within CI.

In theory, now when PEST tests are successful, this workflow will run to build the static assets, upon that workflow being successful, the container image workflows will run.