### PR TITLE
FIX: script for database setup typo

### DIFF
--- a/scripts/db-setup.sh
+++ b/scripts/db-setup.sh
@@ -4,4 +4,4 @@ set -e
 
 php artisan session:table
 php artisan migrate
-php artisan migrate --path=database/migrations/BlogPostMigration.php
+php artisan migrate --path=database/migrations/2025_03_10_205029_blog_posts.php


### PR DESCRIPTION
### Description

There was an incorrect filepath in the database setup script after rebuilding/renaming the migration file. I updated the name of the file so that it would automatically be used with PEST tests.