### PR TITLE
fix: copy default nginx config correctly

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:alpine
 
-COPY ./default.conf /etc/nginx/conf.d/default.conf
+COPY default.conf /etc/nginx/conf.d/default.conf
 
 WORKDIR /var/www
 


### PR DESCRIPTION
### Description

Ideally, this will fix the problem where the NGINX container build fails to find this file.

### Changes
* [copy default nginx config correctly](https://github.com/algchoo/blog/commit/0f1c7259bc116c271cdf0d79294c75ca9b4da865)