### PR TITLE
fix: correct path to the default config file for nginx

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:alpine
 
-COPY default.conf /etc/nginx/conf.d/default.conf
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 
 WORKDIR /var/www
 


### PR DESCRIPTION
This has to be correct this time around. 

The workflow has the runner using `docker buildx build` with `-f nginx/Dockerfile` and I'm pretty sure that Docker sees itself as in the root of the project, rather than the `nginx` directory, which is what I thought beforehand.