### PR TITLE
ci: set base nginx image to use tag stable-alpine

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:stable-alpine
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
### Description

The hope is that using a stable tag will remedy the errors popping up in the Trivy scans after the container builds.

### Changes
* [set base nginx image to use tag stable-alpine](https://github.com/algchoo/blog/commit/302916abf53b90c681e72350158c136dbb23bdd7)