### PR TITLE
cd: update Terraform to use chdir

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -35,13 +35,13 @@ jobs:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
 
     - name: tf-init
-      run: terraform init -input=false
+      run: terraform -chdir=./terraform init -input=false
 
     - name: tf-plan
-      run: terraform plan -out=tfplan -input=false
+      run: terraform -chdir=./terraform plan -out=tfplan -input=false
 
     - name: tf-apply
-      run: terraform apply -input=false -auto-approve tfplan
+      run: terraform -chdir=./terraform apply -input=false -auto-approve tfplan
 
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,9 +1,5 @@
 name: Deploy application containers to Google Cloud Run service
 
-# When do I want to run this workflow?
-# How do I want to run this workflow? (terrform used by runner)
-# need to add secrets to the GitHub project for access to gcloud
-
 on:
   workflow_run:
     workflows:


### PR DESCRIPTION
### Description

The workflow that runs terraform commands wasn't pointing to the directory with the configuration file, so it threw an error saying there was no terraform to `plan` or `apply`, which tracks. Using `-chdir` should fix this problem.

### Changes
* [update tf to use chdir](https://github.com/algchoo/blog/commit/6adaff9c548131979f72e5e7a9d8bc4ebff9c4c4)