### PR TITLE
cd: remove the depends_on for the nginx container

### DIFF
--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -45,7 +45,6 @@ resource "google_cloud_run_v2_service" "default" {
     containers {
       name = "nginx"
       image = "ghcr.io/algchoo/nginx:0739f4e"
-      depends_on = ["blog"]
       resources {
         limits = {
           cpu    = "2"


### PR DESCRIPTION
### Description

Removed the `depends_on` from the Cloud Run terraform, just to see what happens. 

### Changes
* [remove the depends_on for the nginx container](https://github.com/algchoo/blog/commit/5a52ff8d5c3fcd969d1bff282ef25cb52b4f642f)