### PR TITLE
cd: expose cloud run nginx container port

### DIFF
--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -51,6 +51,9 @@ resource "google_cloud_run_v2_service" "default" {
           memory = "1024Mi"
         }
       }
+      ports {
+        container_port = 80
+      }
     }
   }
 }


### PR DESCRIPTION
### Description

The provider documentation suggests that the terraform we have is correct, with two `containers` within the `template` section. See [docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#example-usage---cloudrunv2-service-multicontainer)

The error showing up in our pipeline suggests that perhaps I need to include a port on one or more of these containers. I'm only adding the port to the nginx container, to start.

### Changes
* [expose cloud run nginx container port](https://github.com/algchoo/blog/commit/5acdbeefa1404a9696067fc11cd046bfcc5197d9)