### PR TITLE
cicd: add github login action to prod deploy workflow

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -30,6 +30,13 @@ jobs:
       with:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
 
+    - name: github-login
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: tf-init
       run: terraform -chdir=./terraform init -input=false
 


### PR DESCRIPTION
### Description

This PR updates the production deployment workflow to include an action for logging into the GitHub container registry. I am hoping this allows the runner to deploy everything with Terraform, but it might not work.

### Changes
* [add github login action to prod deploy workflow](https://github.com/algchoo/blog/commit/28299e355f5b6ad2fe584ff4140c0a572dbdd344)