### PR TITLE
cicd: pull images before retagging

### DIFF
--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -99,6 +99,7 @@ jobs:
 
     - name: retag images
       run: |
+        docker pull ghcr.io/algchoo/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
         docker tag ghcr.io/algchoo/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
 
     - name: create ghcr manifest

--- a/.github/workflows/php-container.yaml
+++ b/.github/workflows/php-container.yaml
@@ -104,6 +104,7 @@ jobs:
 
     - name: retag images
       run: |
+        docker pull ghcr.io/algchoo/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
         docker tag ghcr.io/algchoo/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
 
     - name: create ghcr manifest


### PR DESCRIPTION
### Description

I needed to add a step where the images are pulled, so that they can be retagged/pushed to GAR (Google Artifact Repository) 

### Changes
* [pull images before retagging](https://github.com/algchoo/blog/commit/a1b67c6fc8a3947cb7409d7c70395f96e345f053)