### PR TITLE
cicd: add auth actions to container workflows

### DIFF
--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -91,7 +91,12 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: gcloud-login
+    - name: configure-gcp-creds
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+    - name: setup-gcloud
       uses: google-github-actions/setup-gcloud@v2
       with:
         project_id: ${{ secrets.GCP_PROJ_ID }}

--- a/.github/workflows/php-container.yaml
+++ b/.github/workflows/php-container.yaml
@@ -96,7 +96,12 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: gcloud-login
+    - name: configure-gcp-creds
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+    - name: setup-gcloud
       uses: google-github-actions/setup-gcloud@v2
       with:
         project_id: ${{ secrets.GCP_PROJ_ID }}


### PR DESCRIPTION
### Description

I thought I had the correct action called `setup-gcloud`, but I actually need an `auth` action prior to it. It was called out in a warning towards the beginning of one of the jobs that runs, but it wasn't called out in the error.

### Changes
* [add auth actions to container workflows](https://github.com/algchoo/blog/commit/e78b9dc87fdf36ae7658179aefcc3012021bf74e)