### PR TITLE
fix: gcloud auth for container builds

### DIFF
--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -113,24 +113,27 @@ jobs:
         ghcr.io/algchoo/nginx-amd64:${{ steps.get-tag.outputs.tag }} \
         ghcr.io/algchoo/nginx-arm64:${{ steps.get-tag.outputs.tag }}
 
+    - name: create ghcr annotations
+      run: |
+        docker manifest annotate ghcr.io/algchoo/nginx:${{ steps.get-tag.outputs.tag }} ghcr.io/algchoo/nginx-amd64:${{ steps.get-tag.outputs.tag }} --os linux --arch amd64
+        docker manifest annotate ghcr.io/algchoo/nginx:${{ steps.get-tag.outputs.tag }} ghcr.io/algchoo/nginx-arm64:${{ steps.get-tag.outputs.tag }} --os linux --arch arm64
+
+    - name: push ghcr manifest
+      run: docker manifest push ghcr.io/algchoo/nginx:${{ steps.get-tag.outputs.tag }}
+
+    - name: set-gcloud-auth
+      run: gcloud auth configure-docker us-east1-docker.pkg.dev
+
     - name: create gcr manifest
       run: |
         docker manifest create us-east1-docker.pkg.dev/blog-images/nginx:${{ steps.get-tag.outputs.tag }} \
         us-east1-docker.pkg.dev/blog-images/nginx-amd64:${{ steps.get-tag.outputs.tag }} \
         us-east1-docker.pkg.dev/blog-images/nginx-arm64:${{ steps.get-tag.outputs.tag }}
 
-    - name: create ghcr annotations
-      run: |
-        docker manifest annotate ghcr.io/algchoo/nginx:${{ steps.get-tag.outputs.tag }} ghcr.io/algchoo/nginx-amd64:${{ steps.get-tag.outputs.tag }} --os linux --arch amd64
-        docker manifest annotate ghcr.io/algchoo/nginx:${{ steps.get-tag.outputs.tag }} ghcr.io/algchoo/nginx-arm64:${{ steps.get-tag.outputs.tag }} --os linux --arch arm64
-
     - name: create gcr annotations
       run: |
         docker manifest annotate us-east1-docker.pkg.dev/blog-images/nginx:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/nginx-amd64:${{ steps.get-tag.outputs.tag }} --os linux --arch amd64
         docker manifest annotate us-east1-docker.pkg.dev/blog-images/nginx:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/nginx-arm64:${{ steps.get-tag.outputs.tag }} --os linux --arch arm64
-
-    - name: push ghcr manifest
-      run: docker manifest push ghcr.io/algchoo/nginx:${{ steps.get-tag.outputs.tag }}
 
     - name: push gcr manifest
       run: docker manifest push us-east1-docker.pkg.dev/blog-images/nginx:${{ steps.get-tag.outputs.tag }}

--- a/.github/workflows/php-container.yaml
+++ b/.github/workflows/php-container.yaml
@@ -118,24 +118,27 @@ jobs:
         ghcr.io/algchoo/blog-amd64:${{ steps.get-tag.outputs.tag }} \
         ghcr.io/algchoo/blog-arm64:${{ steps.get-tag.outputs.tag }}
 
+    - name: create ghcr annotations
+      run: |
+        docker manifest annotate ghcr.io/algchoo/blog:${{ steps.get-tag.outputs.tag }} ghcr.io/algchoo/blog-amd64:${{ steps.get-tag.outputs.tag }} --os linux --arch amd64
+        docker manifest annotate ghcr.io/algchoo/blog:${{ steps.get-tag.outputs.tag }} ghcr.io/algchoo/blog-arm64:${{ steps.get-tag.outputs.tag }} --os linux --arch arm64
+
+    - name: push ghcr manifest
+      run: docker manifest push ghcr.io/algchoo/blog:${{ steps.get-tag.outputs.tag }}
+
+    - name: set-gcloud-auth
+      run: gcloud auth configure-docker us-east1-docker.pkg.dev
+
     - name: create gcr manifest
       run: |
         docker manifest create us-east1-docker.pkg.dev/blog-images/blog:${{ steps.get-tag.outputs.tag }} \
         us-east1-docker.pkg.dev/blog-images/blog-amd64:${{ steps.get-tag.outputs.tag }} \
         us-east1-docker.pkg.dev/blog-images/blog-arm64:${{ steps.get-tag.outputs.tag }}
 
-    - name: create ghcr annotations
-      run: |
-        docker manifest annotate ghcr.io/algchoo/blog:${{ steps.get-tag.outputs.tag }} ghcr.io/algchoo/blog-amd64:${{ steps.get-tag.outputs.tag }} --os linux --arch amd64
-        docker manifest annotate ghcr.io/algchoo/blog:${{ steps.get-tag.outputs.tag }} ghcr.io/algchoo/blog-arm64:${{ steps.get-tag.outputs.tag }} --os linux --arch arm64
-
     - name: create gcr annotations
       run: |
         docker manifest annotate us-east1-docker.pkg.dev/blog-images/blog:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/blog-amd64:${{ steps.get-tag.outputs.tag }} --os linux --arch amd64
         docker manifest annotate us-east1-docker.pkg.dev/blog-images/blog:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/blog-arm64:${{ steps.get-tag.outputs.tag }} --os linux --arch arm64
-
-    - name: push ghcr manifest
-      run: docker manifest push ghcr.io/algchoo/blog:${{ steps.get-tag.outputs.tag }}
 
     - name: push gcr manifest
       run: docker manifest push us-east1-docker.pkg.dev/blog-images/blog:${{ steps.get-tag.outputs.tag }}


### PR DESCRIPTION
### Description

The steps for building/pushing manifests for the container images have been reorganized so that GHCR goes first, then GAR. This is probably better practice and less confusing than what I had prior. 

### Changes
* [reorg rules for building and pushing manifests, add step to set gcloud auth](https://github.com/algchoo/blog/commit/1f9c34ad7ecef7b628ba69ad1d3966182366069c)