### PR TITLE
fix: validation step for gcloud auth

### DIFF
--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -102,10 +102,20 @@ jobs:
         project_id: ${{ secrets.GCP_PROJ_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}
 
+    - name: Authenticate Docker with GAR
+      run: |-
+        echo "${{ secrets.GCP_SA_KEY }}" | docker login -u _json_key --password-stdin https://us-east1-docker.pkg.dev
+
     - name: retag images
       run: |
         docker pull ghcr.io/algchoo/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
         docker tag ghcr.io/algchoo/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
+
+    - name: validation
+      run: |-
+        echo "Current GCP project: $(gcloud config get-value project)"
+        echo "Intended project: ${{ secrets.GCP_PROJ_ID }}"
+        docker images
 
     - name: create ghcr manifest
       run: |


### PR DESCRIPTION
### Description

Adding a step to validate the project ID being used and the images being retagged.

### Changes
* [adding validation step to check gcp project id and image retag](https://github.com/algchoo/blog/commit/22d04e89047f82642e602a8d64f950dff5df7841)