### PR TITLE
fix: switch to auth v2

### DIFF
--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -92,7 +92,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: configure-gcp-creds
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -100,10 +100,6 @@ jobs:
       uses: google-github-actions/setup-gcloud@v2
       with:
         project_id: ${{ secrets.GCP_PROJ_ID }}
-
-    - name: authenticate-docker-with-gar
-      run: |
-        gcloud auth configure-docker us-east1-docker.pkg.dev
 
     - name: retag images
       run: |


### PR DESCRIPTION
### Description

I can't think of anything else that might be incorrect with this workflow. The actions are the ones I need, the JSON Key for the service account is an actions secret in the repo, the project ID secret has the correct value. The only thing I noticed is that I was on `v1` of the action, rather than `v2`, so hopefully this works.

### Changes
* [switch to auth v2](https://github.com/algchoo/blog/commit/a86f22c91138a0a8fdadeecc3123837e1c2628fa)