### PR TITLE
add step for setting gcloud project

### DIFF
--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -101,6 +101,9 @@ jobs:
       with:
         project_id: ${{ secrets.GCP_PROJ_ID }}
 
+    - name: set-gcloud-project
+      run: gcloud config set project ${{ secrets.GCP_PROJ_ID }}
+
     - name: authenticate-docker-with-gar
       run: |
         gcloud auth configure-docker us-east1-docker.pkg.dev


### PR DESCRIPTION
### Description

The project isn't being set correctly, so here I'm adding a step to run the `gcloud` command for setting the project using the project ID. If this fails, I'll be annoyed, but I'll figure it out eventually.

### Changes
* [add step for setting gcloud project](https://github.com/algchoo/blog/commit/a29b67925025cf84c6a784bdf9414a8e5ae6d3a7)