### PR TITLE
fix: add step for setting gcp project using project ID

### DIFF
--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -129,6 +129,9 @@ jobs:
     - name: set-gcloud-auth
       run: gcloud auth configure-docker us-east1-docker.pkg.dev
 
+    - name: set-gcloud-project
+      run: gcloud config set project ${{ secrets.GCP_PROJ_ID }}
+
     - name: check-gcloud-project
       run: gcloud config list
 


### PR DESCRIPTION
### Description

Added a step to set the `gcloud` project using the project ID

### Changes
* [add step for setting gcp project using project ID](https://github.com/algchoo/blog/commit/2cd5604e4e45c03b1907f5186ef4a5c4538e9ce6)