### PR TITLE
fix: typo in domain for artifact registry repo

### DIFF
--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -104,13 +104,7 @@ jobs:
     - name: retag images
       run: |
         docker pull ghcr.io/algchoo/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
-        docker tag ghcr.io/algchoo/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
-
-    - name: validation
-      run: |
-        echo "Current GCP project: $(gcloud config get-value project)"
-        echo "Intended project: ${{ secrets.GCP_PROJ_ID }}"
-        docker images
+        docker tag ghcr.io/algchoo/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
 
     - name: create ghcr manifest
       run: |
@@ -137,17 +131,17 @@ jobs:
 
     - name: create gcr manifest
       run: |
-        docker manifest create us-east1-docker.pkg.dev/blog-images/nginx:${{ steps.get-tag.outputs.tag }} \
-        us-east1-docker.pkg.dev/blog-images/nginx-amd64:${{ steps.get-tag.outputs.tag }} \
-        us-east1-docker.pkg.dev/blog-images/nginx-arm64:${{ steps.get-tag.outputs.tag }}
+        docker manifest create us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx:${{ steps.get-tag.outputs.tag }} \
+        us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx-amd64:${{ steps.get-tag.outputs.tag }} \
+        us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx-arm64:${{ steps.get-tag.outputs.tag }}
 
     - name: create gcr annotations
       run: |
-        docker manifest annotate us-east1-docker.pkg.dev/blog-images/nginx:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/nginx-amd64:${{ steps.get-tag.outputs.tag }} --os linux --arch amd64
-        docker manifest annotate us-east1-docker.pkg.dev/blog-images/nginx:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/nginx-arm64:${{ steps.get-tag.outputs.tag }} --os linux --arch arm64
+        docker manifest annotate us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx-amd64:${{ steps.get-tag.outputs.tag }} --os linux --arch amd64
+        docker manifest annotate us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx-arm64:${{ steps.get-tag.outputs.tag }} --os linux --arch arm64
 
     - name: push gcr manifest
-      run: docker manifest push us-east1-docker.pkg.dev/blog-images/nginx:${{ steps.get-tag.outputs.tag }}
+      run: docker manifest push us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx:${{ steps.get-tag.outputs.tag }}
 
     - name: scan
       uses: aquasecurity/trivy-action@0.28.0

--- a/.github/workflows/php-container.yaml
+++ b/.github/workflows/php-container.yaml
@@ -110,7 +110,7 @@ jobs:
     - name: retag images
       run: |
         docker pull ghcr.io/algchoo/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
-        docker tag ghcr.io/algchoo/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
+        docker tag ghcr.io/algchoo/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
 
     - name: create ghcr manifest
       run: |
@@ -134,17 +134,17 @@ jobs:
 
     - name: create gcr manifest
       run: |
-        docker manifest create us-east1-docker.pkg.dev/blog-images/blog:${{ steps.get-tag.outputs.tag }} \
-        us-east1-docker.pkg.dev/blog-images/blog-amd64:${{ steps.get-tag.outputs.tag }} \
-        us-east1-docker.pkg.dev/blog-images/blog-arm64:${{ steps.get-tag.outputs.tag }}
+        docker manifest create us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog:${{ steps.get-tag.outputs.tag }} \
+        us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog-amd64:${{ steps.get-tag.outputs.tag }} \
+        us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog-arm64:${{ steps.get-tag.outputs.tag }}
 
     - name: create gcr annotations
       run: |
-        docker manifest annotate us-east1-docker.pkg.dev/blog-images/blog:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/blog-amd64:${{ steps.get-tag.outputs.tag }} --os linux --arch amd64
-        docker manifest annotate us-east1-docker.pkg.dev/blog-images/blog:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/blog-images/blog-arm64:${{ steps.get-tag.outputs.tag }} --os linux --arch arm64
+        docker manifest annotate us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog-amd64:${{ steps.get-tag.outputs.tag }} --os linux --arch amd64
+        docker manifest annotate us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog-arm64:${{ steps.get-tag.outputs.tag }} --os linux --arch arm64
 
     - name: push gcr manifest
-      run: docker manifest push us-east1-docker.pkg.dev/blog-images/blog:${{ steps.get-tag.outputs.tag }}
+      run: docker manifest push us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog:${{ steps.get-tag.outputs.tag }}
 
     - name: scan
       uses: aquasecurity/trivy-action@0.28.0


### PR DESCRIPTION
### Description

I learned that the incorrect project ID is some kind of placeholder when things with auth don't pan out correctly. I noticed I had the GAR URLs without the PROJECT_ID and was curious if adding that would make a difference. Nothing I saw ever specified that it needed to be in the URI, so I assumed that the SA I logged in with would just point containers to the appropriate project (idk how, thinking about it now lol). 

### Changes
* [fix typo in domain for artifact registry repo](https://github.com/algchoo/blog/commit/a4e87d89a51dfc53785de149dc7dbd1933458c24)