### PR TITLE
fix: push the retagged images to artifact registry

### DIFF
--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -105,6 +105,7 @@ jobs:
       run: |
         docker pull ghcr.io/algchoo/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
         docker tag ghcr.io/algchoo/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
+        docker push us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
 
     - name: create ghcr manifest
       run: |

--- a/.github/workflows/php-container.yaml
+++ b/.github/workflows/php-container.yaml
@@ -111,6 +111,7 @@ jobs:
       run: |
         docker pull ghcr.io/algchoo/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
         docker tag ghcr.io/algchoo/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }} us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
+        docker push us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
 
     - name: create ghcr manifest
       run: |


### PR DESCRIPTION
### Description

You have to push the images before you can create the manifests. This is the way.

### Changes
* [push the retagged images so that the manifest can be created](https://github.com/algchoo/blog/commit/899d31adb93f078d0bbca861c429de15a99fac12)