### PR TITLE
fix: authenticate before pushing images

### DIFF
--- a/.github/workflows/nginx-container.yaml
+++ b/.github/workflows/nginx-container.yaml
@@ -101,6 +101,9 @@ jobs:
       with:
         project_id: ${{ secrets.GCP_PROJ_ID }}
 
+    - name: set-gcloud-auth
+      run: gcloud auth configure-docker us-east1-docker.pkg.dev
+
     - name: retag images
       run: |
         docker pull ghcr.io/algchoo/nginx-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
@@ -120,15 +123,6 @@ jobs:
 
     - name: push ghcr manifest
       run: docker manifest push ghcr.io/algchoo/nginx:${{ steps.get-tag.outputs.tag }}
-
-    - name: set-gcloud-auth
-      run: gcloud auth configure-docker us-east1-docker.pkg.dev
-
-    - name: set-gcloud-project
-      run: gcloud config set project ${{ secrets.GCP_PROJ_ID }}
-
-    - name: check-gcloud-project
-      run: gcloud config list
 
     - name: create gcr manifest
       run: |

--- a/.github/workflows/php-container.yaml
+++ b/.github/workflows/php-container.yaml
@@ -107,6 +107,9 @@ jobs:
         project_id: ${{ secrets.GCP_PROJ_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}
 
+    - name: set-gcloud-auth
+      run: gcloud auth configure-docker us-east1-docker.pkg.dev
+
     - name: retag images
       run: |
         docker pull ghcr.io/algchoo/blog-${{ matrix.platform }}:${{ steps.get-tag.outputs.tag }}
@@ -126,12 +129,6 @@ jobs:
 
     - name: push ghcr manifest
       run: docker manifest push ghcr.io/algchoo/blog:${{ steps.get-tag.outputs.tag }}
-
-    - name: set-gcloud-auth
-      run: gcloud auth configure-docker us-east1-docker.pkg.dev
-
-    - name: check-gcloud-project
-      run: gcloud config list
 
     - name: create gcr manifest
       run: |


### PR DESCRIPTION
### Description

I did not authenticate before trying to push the retagged images, that's my mistake. Removed a few unnecessary steps, as well.

### Changes
* [remove unneeded steps and configure gcloud docker auth before pushing images](https://github.com/algchoo/blog/commit/089dd461485dd1f34f7afd7eb64ca917a2cd561d)