### PR TITLE
fix: cloud run terraform uses artifact registry images

### DIFF
--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -25,7 +25,7 @@ resource "google_cloud_run_v2_service" "default" {
   template {
     containers {
       name = "blog"
-      image = "ghcr.io/algchoo/blog:0739f4e"
+      image = "us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog:3442b8c"
       env {
         name = "APP_KEY"
         value_source {
@@ -44,7 +44,7 @@ resource "google_cloud_run_v2_service" "default" {
     }
     containers {
       name = "nginx"
-      image = "ghcr.io/algchoo/nginx:0739f4e"
+      image = "us-east1-docker.pkg.dev/dumpster-blog/blog-images/nginx:3442b8c"
       resources {
         limits = {
           cpu    = "2"


### PR DESCRIPTION
### Description

The terraform configuration for the Cloud Run deployment originally pointed to GitHub Container Registry images, but that is not supported in Cloud Run, so now it points to images in Artifact Registry, which is supported.

### Changes
* [updated the cloud run terraform to use artifact registry images](https://github.com/algchoo/blog/commit/773703cd054ba2aac721be9611c9f6e89eda7f2e)