### PR TITLE
fix: set blog image tag to an existing tag

### DIFF
--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -25,7 +25,7 @@ resource "google_cloud_run_v2_service" "default" {
   template {
     containers {
       name = "blog"
-      image = "us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog:3442b8c"
+      image = "us-east1-docker.pkg.dev/dumpster-blog/blog-images/blog:b1b9066"
       env {
         name = "APP_KEY"
         value_source {


### PR DESCRIPTION
### Description

Updated the blog image tag to an existing tag, instead of just guessing.

### Changes
* [updated the blog image tag to an existing tag](https://github.com/algchoo/blog/commit/2ac2270d8e91d033ade876e54d49213077c560d1)