### PR TITLE
fix: update terraform to use correct service account

### DIFF
--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -61,5 +61,5 @@ resource "google_cloud_run_v2_service" "default" {
 resource "google_secret_manager_secret_iam_member" "secret_access" {
   secret_id = data.google_secret_manager_secret_version.blog_app_key.secret
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_cloud_run_v2_service.default.template.0.service_account}"
+  member    = "serviceAccount:cloud-run-deploy@dumpster-blog.iam.gserviceaccount.com"
 }


### PR DESCRIPTION
### Description

The terraform resource for accessing secrets was trying to use the wrong service account. It should not use the appropriate one.

### Changes
* [updated the secret access resource to use the appropriate service account](https://github.com/algchoo/blog/commit/f6ca9c7ae15cd266d69e67528c689ff413b827db) 

