### PR TITLE
fix: remove tf that applied iam policy to secret

### DIFF
--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -58,9 +58,3 @@ resource "google_cloud_run_v2_service" "default" {
     }
   }
 }
-
-resource "google_secret_manager_secret_iam_member" "secret_access" {
-  secret_id = data.google_secret_manager_secret_version.blog_app_key.secret
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:cloud-run-deploy@dumpster-blog.iam.gserviceaccount.com"
-}


### PR DESCRIPTION
### Description

I removed the terraform resource that was attempting to set an IAM policy on a secret. The service account has access to the secrets, so it should be fine.

### Changes
* [remove tf that applied iam policy to secret](https://github.com/algchoo/blog/commit/6ae5aa497b410908ea7d4b56345312b4884d546d)